### PR TITLE
Some fixes to libcapsicum

### DIFF
--- a/src/libcapsicum_host.c
+++ b/src/libcapsicum_host.c
@@ -303,7 +303,7 @@ lch_startfd(int fd_binary, const char *binname, char *const argv[],
 		goto out_error;
 	}
 
-	pid = pdfork(&fd_procdesc);
+	pid = pdfork(&fd_procdesc, 0);
 	if (pid < 0) {
 		fd_procdesc = -1;
 		goto out_error;

--- a/test/fdlist.c
+++ b/test/fdlist.c
@@ -23,8 +23,8 @@ test_fdlist()
 
 	REQUIRE(fd = open("/tmp/libcapsicum.fdlist", O_RDWR | O_CREAT));
 
-	CHECK_SYSCALL_SUCCEEDS(lc_fdlist_add(fdlistp,
-	    subsystem, classname, "raw", fd));
+	CHECK(lc_fdlist_add(fdlistp,
+	    subsystem, classname, "raw", fd) == 0);
 
 	return success;
 }


### PR DESCRIPTION
Hi,
this fixes one compilation error and one testing bug.
- Supply extra argument to pdfork(2);
- Use CHECK() instead of CHECK_SYSCALL_SUCCEEDS() because lc_fdlist_add(3) is actually a library function, not a system call.
