### PR TITLE
Fix "make install" target

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,5 @@
 PROG=	test-libcapsicum
+INTERNALPROG=	yes
 SRCS=	\
 	ctest.c \
 	main.c \


### PR DESCRIPTION
Hi Jonathan,
this (tiny!!!) patch fixes top-level "make install" target, which earlier used to break while installing in test/ subdirectory. Note that INTERNALPROG seems not to be documented anywhere, but looking at the bsd.prog.mk sources it seems to serve for disabling 'make install' for current Makefile.
